### PR TITLE
Triton to XSMM

### DIFF
--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -121,9 +121,6 @@ class CPUBackend(BaseBackend):
         passes.common.add_cse(pm)
         passes.common.add_licm(pm)
         passes.common.add_symbol_dce(pm)
-        if opt.enable_triton_xsmm:
-            cpu.passes.ttcpuir.add_convert_triton_to_xsmm(pm)
-            passes.common.add_canonicalizer(pm)
         pm.run(mod)
         return mod
 
@@ -132,6 +129,9 @@ class CPUBackend(BaseBackend):
         # TTIR -> TTCIR
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
+        if opt.enable_triton_xsmm:
+            cpu.passes.ttcpuir.add_convert_triton_to_xsmm(pm)
+            passes.common.add_canonicalizer(pm)
         cpu.passes.ttcpuir.add_scalarize(pm)
         cpu.passes.ttcpuir.add_convert_memory_ops(pm)
         cpu.passes.ttcpuir.add_convert_ptr_ops(pm)

--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -41,7 +41,8 @@ class CPUOptions:
     enable_fp_fusion: bool = True
     max_num_imprecise_acc_default: int = 0
     enable_fast_math: bool = True
-    enable_xsmm: bool = False
+    enable_vector_xsmm: bool = False
+    enable_triton_xsmm: bool = False
     vec_lib: Optional[str] = 'libsleef'
     warp_size: int = 1
 
@@ -88,8 +89,10 @@ class CPUBackend(BaseBackend):
         if "supported_fp8_dtypes" not in args:
             supported_fp8_dtypes = set(CPUOptions.supported_fp8_dtypes)
             args["supported_fp8_dtypes"] = tuple(sorted(supported_fp8_dtypes))
-        if "enable_xsmm" not in args:
-            args["enable_xsmm"] = os.getenv("TRITON_CPU_XSMM", "0") != "0"
+        if "enable_vector_xsmm" not in args:
+            args["enable_vector_xsmm"] = os.getenv("TRITON_CPU_VECTOR_XSMM", "0") != "0"
+        if "enable_triton_xsmm" not in args:
+            args["enable_triton_xsmm"] = os.getenv("TRITON_CPU_TRITON_XSMM", "0") != "0"
         return CPUOptions(**args)
 
     def pack_metadata(self, metadata):
@@ -118,6 +121,9 @@ class CPUBackend(BaseBackend):
         passes.common.add_cse(pm)
         passes.common.add_licm(pm)
         passes.common.add_symbol_dce(pm)
+        if opt.enable_triton_xsmm:
+            cpu.passes.ttcpuir.add_convert_triton_to_xsmm(pm)
+            passes.common.add_canonicalizer(pm)
         pm.run(mod)
         return mod
 
@@ -181,7 +187,7 @@ class CPUBackend(BaseBackend):
         # TritonCPU -> LLVM-IR (MLIR)
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
-        if options.enable_xsmm:
+        if options.enable_vector_xsmm:
             cpu.passes.ttcpuir.add_convert_vector_to_xsmm(pm)
         cpu.passes.ttcpuir.add_lower_vector_multi_dim(pm)
         cpu.passes.ttcpuir.add_expand_strided_metadata(pm)
@@ -249,7 +255,7 @@ class CPUBackend(BaseBackend):
             Path(asm_path).write_text(src)
             lib_dirs = cpu_driver.library_dirs
             libs = ["gcc", "m", "TritonCPURuntime", "sleef"]
-            if options.enable_xsmm:
+            if options.enable_vector_xsmm or options.enable_triton_xsmm:
                 libs.extend(["xsmm", "TritonCPUXsmmRuntime"])
             so = _build("kernel", asm_path, tmpdir, lib_dirs, cpu_driver.include_dirs, libs)
             with open(so, "rb") as f:

--- a/third_party/cpu/include/Xsmm/Passes.h
+++ b/third_party/cpu/include/Xsmm/Passes.h
@@ -48,6 +48,14 @@ namespace vector {
 class VectorDialect;
 } // namespace vector
 
+namespace triton {
+class TritonDialect;
+
+namespace cpu {
+class TritonCPUDialect;
+} // namespace cpu
+} // namespace triton
+
 } // namespace mlir
 
 namespace mlir {

--- a/third_party/cpu/include/Xsmm/Passes.td
+++ b/third_party/cpu/include/Xsmm/Passes.td
@@ -14,4 +14,16 @@ def ConvertVectorToXsmm : Pass<"triton-cpu-convert-vector-to-xsmm", "mlir::Modul
 			                    "LLVM::LLVMDialect"];
 }
 
+def ConvertTritonToXsmm : Pass<"triton-cpu-convert-triton-to-xsmm", "mlir::ModuleOp"> {
+ let summary = "Convert triton to xsmm";
+ let description = [{
+   Convert triton operations to XSMM operations.
+ }];
+ let dependentDialects = ["func::FuncDialect",
+                          "memref::MemRefDialect",
+                          "triton::TritonDialect",
+                          "triton::cpu::TritonCPUDialect",
+			                    "LLVM::LLVMDialect"];
+}
+
 #endif

--- a/third_party/cpu/lib/TritonToTritonCPU/ConvertDotOp.cpp
+++ b/third_party/cpu/lib/TritonToTritonCPU/ConvertDotOp.cpp
@@ -7,6 +7,7 @@
 #include "mlir/Dialect/Index/IR/IndexOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/AffineMap.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 

--- a/third_party/cpu/lib/Xsmm/CMakeLists.txt
+++ b/third_party/cpu/lib/Xsmm/CMakeLists.txt
@@ -1,4 +1,7 @@
+get_property(extension_libs GLOBAL PROPERTY MLIR_EXTENSION_LIBS)
+
 add_triton_library(TritonCPUXsmm
+    ConvertTritonToXsmm.cpp
     ConvertVectorToXsmm.cpp
     VnniUtils.cpp
     ValueUtils.cpp
@@ -11,6 +14,7 @@ add_triton_library(TritonCPUXsmm
     xsmm
 
     LINK_LIBS PUBLIC
+    ${extension_libs}
     MLIRIR
     MLIRPass
     MLIRVectorDialect
@@ -19,6 +23,7 @@ add_triton_library(TritonCPUXsmm
     MLIRLLVMDialect
     MLIRInferTypeOpInterface
     MLIRLinalgUtils
+    TritonCPUIR
     xsmm
 )
 

--- a/third_party/cpu/lib/Xsmm/ConvertTritonToXsmm.cpp
+++ b/third_party/cpu/lib/Xsmm/ConvertTritonToXsmm.cpp
@@ -1,0 +1,138 @@
+//===- ConvertTritonToXsmm.cpp ----------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "cpu/include/Xsmm/Passes.h"
+
+#include "ValueUtils.h"
+#include "VnniUtils.h"
+#include "XsmmUtils.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Utils/IndexingUtils.h"
+#include "mlir/IR/BuiltinDialect.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonCPU/IR/Dialect.h"
+#include "llvm/Support/Debug.h"
+
+#include <optional>
+#include <utility>
+
+using namespace mlir;
+using namespace mlir::vector;
+using namespace mlir::func;
+using namespace mlir::triton;
+using namespace mlir::triton::cpu;
+
+namespace mlir {
+namespace triton {
+namespace cpu {
+#define GEN_PASS_DEF_CONVERTTRITONTOXSMM
+#include "cpu/include/Xsmm/Passes.h.inc"
+} // namespace cpu
+} // namespace triton
+} // namespace mlir
+
+namespace {
+
+static Value getMemrefSource(PatternRewriter &rewriter, Operation *op,
+                             TypedValue<RankedTensorType> operand) {
+  Location loc = op->getLoc();
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(op);
+
+  RankedTensorType tensorTy = operand.getType();
+  MemRefType memTy =
+      MemRefType::get(tensorTy.getShape(), tensorTy.getElementType());
+  auto alloca = rewriter.create<memref::AllocaOp>(loc, memTy);
+  rewriter.create<triton::cpu::StoreOp>(loc, operand, alloca);
+
+  return alloca;
+}
+
+struct DotToXsmm : public OpRewritePattern<triton::DotOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(triton::DotOp dotOp,
+                                PatternRewriter &rewriter) const override {
+    Location loc = dotOp.getLoc();
+    MLIRContext *ctx = dotOp.getContext();
+
+    // Dot op computes standard (batch) GEMM.
+    SmallVector<AffineMap> indexingMaps;
+    TypedValue<RankedTensorType> res = dotOp.getD();
+    uint32_t rank = res.getType().getRank();
+    if (rank == 2) {
+      indexingMaps.push_back(
+          AffineMap::getMultiDimMapWithTargets(3, {0, 2}, ctx));
+      indexingMaps.push_back(
+          AffineMap::getMultiDimMapWithTargets(3, {2, 1}, ctx));
+      indexingMaps.push_back(
+          AffineMap::getMultiDimMapWithTargets(3, {0, 1}, ctx));
+    } else if (rank == 3) {
+      indexingMaps.push_back(
+          AffineMap::getMultiDimMapWithTargets(4, {0, 1, 3}, ctx));
+      indexingMaps.push_back(
+          AffineMap::getMultiDimMapWithTargets(4, {0, 3, 2}, ctx));
+      indexingMaps.push_back(
+          AffineMap::getMultiDimMapWithTargets(4, {0, 1, 2}, ctx));
+    }
+    if (indexingMaps.size() == 0)
+      return rewriter.notifyMatchFailure(dotOp, "unsupported indexing maps");
+
+    TypedValue<RankedTensorType> lhs = dotOp.getA();
+    TypedValue<RankedTensorType> rhs = dotOp.getB();
+    TypedValue<RankedTensorType> acc = dotOp.getC();
+
+    SmallVector<Attribute> flags;
+    Value lhsBuf = getMemrefSource(rewriter, dotOp, lhs);
+    Value rhsBuf = getMemrefSource(rewriter, dotOp, rhs);
+    Value accBuf = getMemrefSource(rewriter, dotOp, acc);
+    SmallVector<Value> inputs{lhsBuf, rhsBuf, accBuf};
+    SmallVector<Value> outputs{nullptr};
+
+    auto brgemmInfo = xsmm::utils::isMappableToBrgemm(rewriter, dotOp, inputs,
+                                                      outputs, indexingMaps);
+    if (failed(brgemmInfo))
+      return rewriter.notifyMatchFailure(dotOp, "not mappable to XSMM");
+    if (brgemmInfo->isVnni)
+      return rewriter.notifyMatchFailure(dotOp, "VNNI support NYI");
+
+    auto xsmmFuncs = xsmm::utils::buildBrgemmCalls(
+        rewriter, dotOp, ValueRange{lhsBuf, rhsBuf, accBuf}, *brgemmInfo,
+        flags);
+    auto loadOp =
+        rewriter.create<triton::cpu::LoadOp>(loc, res.getType(), accBuf);
+
+    rewriter.replaceOp(dotOp, loadOp);
+
+    return success();
+  }
+};
+
+struct ConvertTritonToXsmm
+    : public triton::cpu::impl::ConvertTritonToXsmmBase<ConvertTritonToXsmm> {
+  using ConvertTritonToXsmmBase::ConvertTritonToXsmmBase;
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+    patterns.add<DotToXsmm>(context);
+    if (failed(mlir::applyPatternsAndFoldGreedily(getOperation(),
+                                                  std::move(patterns))))
+      return signalPassFailure();
+  }
+};
+
+} // namespace

--- a/third_party/cpu/lib/Xsmm/XsmmUtils.h
+++ b/third_party/cpu/lib/Xsmm/XsmmUtils.h
@@ -108,7 +108,7 @@ SmallVector<Value> getOperands(OpBuilder &builder, Location loc,
                                ValueRange operands, IntegerAttr dataTypeAttr);
 
 FailureOr<BrgemmInfo> isMappableToBrgemm(PatternRewriter &rewriter,
-                                         vector::ContractionOp contractOp,
+                                         Operation *contractOp,
                                          SmallVector<Value> &inputs,
                                          SmallVector<Value> &output,
                                          ArrayRef<AffineMap> indexingMap);
@@ -118,11 +118,10 @@ makeMinorDimensionsInnerMost(RewriterBase &rewriter,
                              vector::ContractionOp contractOp, unsigned m,
                              unsigned n, unsigned k, IntegerAttr type);
 std::optional<unsigned> getPosInCodomain(unsigned dim, Value operand,
-                                         vector::ContractionOp contractOp,
-                                         AffineMap map);
+                                         Operation *contractOp, AffineMap map);
 FailureOr<xsmm::BrgemmInfo>
-checkAccess(PatternRewriter &rewriter, vector::ContractionOp contractOp,
-            unsigned m, unsigned n, SmallVector<unsigned, 2> kVector,
+checkAccess(PatternRewriter &rewriter, Operation *contractOp, unsigned m,
+            unsigned n, SmallVector<unsigned, 2> kVector,
             std::optional<unsigned> batchPos, SmallVector<Value> inputs,
             ArrayRef<AffineMap> indexingMap);
 

--- a/third_party/cpu/triton_cpu.cc
+++ b/third_party/cpu/triton_cpu.cc
@@ -10,6 +10,7 @@
 #include "mlir/Conversion/Passes.h"
 #include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVMPass.h"
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"
+#include "mlir/Dialect/Func/Extensions/AllExtensions.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Dialect/Vector/Transforms/Passes.h"
 #include "mlir/Pass/Pass.h"
@@ -148,6 +149,9 @@ void init_triton_cpu_passes_ttcpuir(py::module &&m) {
   m.def("add_expand_strided_metadata", [](mlir::PassManager &pm) {
     pm.addPass(mlir::memref::createExpandStridedMetadataPass());
   });
+  m.def("add_convert_triton_to_xsmm", [](mlir::PassManager &pm) {
+    pm.addPass(mlir::triton::cpu::createConvertTritonToXsmm());
+  });
 }
 
 void init_triton_cpu(py::module &&m) {
@@ -159,6 +163,7 @@ void init_triton_cpu(py::module &&m) {
     registry.insert<mlir::triton::cpu::TritonCPUDialect,
                     mlir::vector::VectorDialect>();
     mlir::triton::cpu::registerTritonOpScalarizeExternalModels(registry);
+    mlir::func::registerAllExtensions(registry);
     context.appendDialectRegistry(registry);
     context.loadAllAvailableDialects();
   });


### PR DESCRIPTION
Adds lowering pass from triton to XSMM microkernels.
    XSMM utility APIs are generalized to work on opaque operations
    representing contractions.
    
    A simple pattern mapping tt.dot to XSMM kernel is added.
    The runtime lowering to XSMM is now controlled by two separate flags:
    - TRITON_CPU_VECTOR_XSMM=1 to lower from vector as before
    - TRITON_CPU_TRITON_XSMM=1 to lower from triton ops

NOTE: Depends on #3 - ignore first commit