### PR TITLE
Enable bfloat16 support

### DIFF
--- a/python/tutorials/03-matrix-multiplication-cpu.py
+++ b/python/tutorials/03-matrix-multiplication-cpu.py
@@ -154,14 +154,14 @@ import torch
 import triton
 import triton.language as tl
 
-# It depends on CPU cache sizes, but 16 looks better.
-BLOCK_SIZE_M = 16
-BLOCK_SIZE_N = 16
-BLOCK_SIZE_K = 16
+# It depends on CPU cache sizes.
+BLOCK_SIZE_M = 64
+BLOCK_SIZE_N = 64
+BLOCK_SIZE_K = 64
 GROUP_SIZE_M = 8
 USE_GPU = False
 USE_BLOCK_POINTERS = False
-
+DATA_TYPE = torch.float32
 
 @triton.jit
 def matmul_kernel(
@@ -269,7 +269,7 @@ def matmul_kernel(
             b_ptrs += BLOCK_SIZE_K * stride_bk
 
     # Convert the accumulator to the output matrix C's type if needed.
-    c = accumulator
+    c = accumulator.to(c_ptr.type.element_ty)
 
     if USE_BLOCK_POINTERS:
         # TODO: masking
@@ -337,8 +337,8 @@ torch.manual_seed(0)
 
 triton.runtime.driver.set_active_to_cpu(experimental=False)
 
-a = torch.randn((1024, 1024), device='cpu', dtype=torch.float32)
-b = torch.randn((1024, 1024), device='cpu', dtype=torch.float32)
+a = torch.randn((512, 512), device='cpu', dtype=DATA_TYPE)
+b = torch.randn((512, 512), device='cpu', dtype=DATA_TYPE)
 triton_output = matmul(a, b, None)
 torch_output = torch.matmul(a, b)
 print(f"triton_cpu_output_with_{a.dtype}_inputs={triton_output}")
@@ -346,6 +346,9 @@ print(f"torch_cpu_output_with_{a.dtype}_inputs={torch_output}")
 rtol = 0
 if torch.allclose(triton_output, torch_output, atol=1e-2, rtol=rtol):
     print("✅ TritonCPU and TorchCPU match")
+elif DATA_TYPE == torch.bfloat16 and torch.allclose(triton_output, torch_output, atol=2e-0, rtol=rtol):
+    print("⚠️ TritonCPU and TorchCPU rounding errors, the maximum difference is "
+          f'{torch.max(torch.abs(triton_output - torch_output))}')
 else:
     print("❌ TritonCPU and TorchCPU differ, the maximum difference is "
           f'{torch.max(torch.abs(triton_output - torch_output))}')
@@ -360,11 +363,17 @@ else:
 # We can now compare the performance of our kernel against that of Pytorch. Here we focus on square matrices,
 # but feel free to arrange this script as you wish to benchmark any other matrix shape.
 
+# LINE_VALS = [
+#     'triton-cpu-single', 'triton-cpu', 'triton-cpu-single-v2', 'triton-cpu-v2', 'torch-cpu-native', 'torch-cpu-compile']
+# LINE_NAMES = ['TritonCPU 1', 'TritonCPU', 'TritonCPU 1-v2', 'TritonCPU-v2', 'TorchCPU (native)', 'TorchCPU (compile)']
+# LINE_STYLES = [('blue', '--'), ('blue', '-'), ('red', '--'), ('red', '-'), ('green', '--'), ('green', '-')]
+
+# Disabled v2 benchmarking.
+# v2 lowering effectively fails for tiles larger than 16 and throws errors on bf16 data type.
 LINE_VALS = [
-    'triton-cpu-single', 'triton-cpu', 'triton-cpu-single-v2', 'triton-cpu-v2', 'torch-cpu-native', 'torch-cpu-compile'
-]
-LINE_NAMES = ['TritonCPU 1', 'TritonCPU', 'TritonCPU 1-v2', 'TritonCPU-v2', 'TorchCPU (native)', 'TorchCPU (compile)']
-LINE_STYLES = [('blue', '--'), ('blue', '-'), ('red', '--'), ('red', '-'), ('green', '--'), ('green', '-')]
+    'triton-cpu-single', 'triton-cpu', 'torch-cpu-native', 'torch-cpu-compile']
+LINE_NAMES = ['TritonCPU 1', 'TritonCPU', 'TorchCPU (native)', 'TorchCPU (compile)']
+LINE_STYLES = [('blue', '--'), ('blue', '-'), ('green', '--'), ('green', '-')]
 
 if USE_GPU and triton.runtime.driver.get_active_gpus():
     triton.runtime.driver.set_active_to_gpu()
@@ -396,6 +405,7 @@ if USE_GPU and triton.runtime.driver.get_active_gpus():
 # To make things easier, Triton has a set of built-in utilities that allow us to concisely plot the performance of our custom ops.
 # for different problem sizes.
 
+STR_TYPE = str(DATA_TYPE).rsplit('.')[-1]
 
 @triton.testing.perf_report(
     triton.testing.Benchmark(
@@ -408,15 +418,15 @@ if USE_GPU and triton.runtime.driver.get_active_gpus():
         ylabel='GFLOPS',  # Label name for the y-axis.
         plot_name=
         # Name for the plot. Used also as a file name for saving the plot.
-        f'matmul-performance-fp32 (BLOCK_SIZE_M={BLOCK_SIZE_M}, BLOCK_SIZE_N={BLOCK_SIZE_N}, BLOCK_SIZE_K={BLOCK_SIZE_K}, GROUP_SIZE_M={GROUP_SIZE_M})',
+        f'matmul-performance-{STR_TYPE} (BLOCK_SIZE_M={BLOCK_SIZE_M}, BLOCK_SIZE_N={BLOCK_SIZE_N}, BLOCK_SIZE_K={BLOCK_SIZE_K}, GROUP_SIZE_M={GROUP_SIZE_M})',
         args={},  # Values for function arguments not in `x_names` and `y_name`.
     ))
 def benchmark(M, N, K, provider):
     import os
 
     device = 'cpu' if 'cpu' in provider else 'cuda'
-    a = torch.randn((M, K), device=device, dtype=torch.float32)
-    b = torch.randn((K, N), device=device, dtype=torch.float32)
+    a = torch.randn((M, K), device=device, dtype=DATA_TYPE)
+    b = torch.randn((K, N), device=device, dtype=DATA_TYPE)
 
     if device == 'cpu':
         c = torch.empty((M, N), device=a.device, dtype=a.dtype)

--- a/third_party/cpu/lib/Xsmm/XsmmUtils.h
+++ b/third_party/cpu/lib/Xsmm/XsmmUtils.h
@@ -19,6 +19,7 @@
 #include "llvm/ADT/SmallVector.h"
 
 #include <cstdint>
+#include <optional>
 #include <utility>
 
 using namespace mlir;
@@ -104,8 +105,10 @@ int64_t getOredFlags(ArrayAttr flags);
 
 SmallVector<Type> extractInvokeOperandTypes(OpBuilder &builder,
                                             ValueRange operands);
-SmallVector<Value> getOperands(OpBuilder &builder, Location loc,
-                               ValueRange operands, IntegerAttr dataTypeAttr);
+SmallVector<Value>
+getOperands(OpBuilder &builder, Location loc, ValueRange operands,
+            IntegerAttr dataTypeAttr,
+            std::optional<IntegerAttr> outDataTypeAttr = std::nullopt);
 
 FailureOr<BrgemmInfo> isMappableToBrgemm(PatternRewriter &rewriter,
                                          Operation *contractOp,
@@ -140,9 +143,11 @@ func::CallOp buildDispatchCall(RewriterBase &rewriter, Location loc,
                                ArrayRef<Value> dispatchOperands,
                                ArrayRef<Type> dispatchOperandTypes,
                                ModuleOp module, FlatSymbolRefAttr fnName);
-func::CallOp buildInvokeCall(RewriterBase &rewriter, Location loc,
-                             ModuleOp module, SmallVector<Value> operands,
-                             StringRef invokeName, DataTypeAttr dtype);
+func::CallOp
+buildInvokeCall(RewriterBase &rewriter, Location loc, ModuleOp module,
+                SmallVector<Value> operands, StringRef invokeName,
+                DataTypeAttr dtype,
+                std::optional<DataTypeAttr> outDtype = std::nullopt);
 
 // Create a pair of XSMM dispatch and invoke (BR)GEMM calls.
 std::pair<Operation *, Operation *>

--- a/third_party/cpu/lib/Xsmm/runtime/XsmmRunnerUtils.h
+++ b/third_party/cpu/lib/Xsmm/runtime/XsmmRunnerUtils.h
@@ -19,9 +19,9 @@
 #include "mlir/ExecutionEngine/Float16bits.h"
 #include "mlir/ExecutionEngine/RunnerUtils.h"
 
-extern "C" MLIR_RUNNERUTILS_EXPORT int64_t
-xsmm_gemm_dispatch(const libxsmm_datatype, int64_t, int64_t, int64_t, int64_t,
-                   int64_t, int64_t, const libxsmm_gemm_flags);
+extern "C" MLIR_RUNNERUTILS_EXPORT int64_t xsmm_gemm_dispatch(
+    const libxsmm_datatype, const libxsmm_datatype, int64_t, int64_t, int64_t,
+    int64_t, int64_t, int64_t, const libxsmm_gemm_flags);
 
 extern "C" MLIR_RUNNERUTILS_EXPORT int64_t xsmm_unary_dispatch(
     const libxsmm_meltw_unary_type, const libxsmm_datatype, int64_t, int64_t,
@@ -32,8 +32,8 @@ extern "C" MLIR_RUNNERUTILS_EXPORT int64_t xsmm_binary_dispatch(
     int64_t, int64_t, int64_t, const libxsmm_meltw_binary_flags);
 
 extern "C" MLIR_RUNNERUTILS_EXPORT int64_t xsmm_brgemm_dispatch(
-    const libxsmm_datatype, int64_t, int64_t, int64_t, int64_t, int64_t,
-    int64_t, int64_t, int64_t, const libxsmm_gemm_flags);
+    const libxsmm_datatype, const libxsmm_datatype, int64_t, int64_t, int64_t,
+    int64_t, int64_t, int64_t, int64_t, int64_t, const libxsmm_gemm_flags);
 
 extern "C" MLIR_RUNNERUTILS_EXPORT int64_t xsmm_fused_brgemm_dispatch(
     const libxsmm_datatype data_type, int64_t m, int64_t n, int64_t k,
@@ -49,9 +49,10 @@ extern "C" MLIR_RUNNERUTILS_EXPORT int64_t xsmm_intel_amx_tile_config_dispatch(
     int64_t, int64_t, int64_t, const libxsmm_gemm_flags);
 
 extern "C" MLIR_RUNNERUTILS_EXPORT void
-xsmm_gemm_invoke(const libxsmm_datatype dType, int64_t addr, void *alignedPtrA,
-                 int64_t offsetA, void *alignedPtrB, int64_t offsetB,
-                 void *alignedPtrC, int64_t offsetC);
+xsmm_gemm_invoke(const libxsmm_datatype dType, const libxsmm_datatype out_dtype,
+                 int64_t addr, void *alignedPtrA, int64_t offsetA,
+                 void *alignedPtrB, int64_t offsetB, void *alignedPtrC,
+                 int64_t offsetC);
 
 extern "C" MLIR_RUNNERUTILS_EXPORT void
 xsmm_unary_invoke(const libxsmm_datatype dType, int64_t addr,
@@ -67,11 +68,10 @@ xsmm_binary_invoke(const libxsmm_datatype dType, int64_t addr,
                    void *alignedPtrLhs, int64_t offsetLhs, void *alignedPtrRhs,
                    int64_t offsetRhs, void *alignedPtrOut, int64_t offsetOut);
 
-extern "C" MLIR_RUNNERUTILS_EXPORT void
-xsmm_brgemm_invoke(const libxsmm_datatype dType, int64_t addr,
-                   void *alignedPtrA, int64_t offsetA, void *alignedPtrB,
-                   int64_t offsetB, void *alignedPtrC, int64_t offsetC,
-                   int64_t numBatches);
+extern "C" MLIR_RUNNERUTILS_EXPORT void xsmm_brgemm_invoke(
+    const libxsmm_datatype dType, const libxsmm_datatype out_dtype,
+    int64_t addr, void *alignedPtrA, int64_t offsetA, void *alignedPtrB,
+    int64_t offsetB, void *alignedPtrC, int64_t offsetC, int64_t numBatches);
 
 extern "C" MLIR_RUNNERUTILS_EXPORT void xsmm_fused_brgemm_invoke(
     const libxsmm_datatype dType, int64_t addr, void *alignedPtrA,


### PR DESCRIPTION
Extends XSMM code generation to allow for mixed precision computations to match triton requirements for <bf16 x bf16 -> f32> contraction. Data type selection is added as a global variable to the matmul tutorial.

BF16 suffers from some inaccuracies compared to PyTorch baseline. However, the difference appears to be the same between native triton-cpu and XSMM lowering.
The matmul tutorial is aligned more with the main branch.
V2 backend benchmarking is disable due to its instabilities.
Default tile sizes are increased to improve general performance.