### PR TITLE
Dynamic shape/stride/offset support by way of memref.extract_strided_metadata

### DIFF
--- a/third_party/cpu/lib/Xsmm/ConvertTritonToXsmm.cpp
+++ b/third_party/cpu/lib/Xsmm/ConvertTritonToXsmm.cpp
@@ -224,14 +224,13 @@ struct DotToXsmm : public OpRewritePattern<triton::DotOp> {
 
     auto brgemmInfo = xsmm::utils::isMappableToBrgemm(rewriter, dotOp, inputs,
                                                       outputs, indexingMaps);
-    if (failed(brgemmInfo))
-      return rewriter.notifyMatchFailure(dotOp, "not mappable to XSMM");
-    if (brgemmInfo->isVnni)
-      return rewriter.notifyMatchFailure(dotOp, "VNNI support NYI");
+    if (failed(brgemmInfo)) {
+      assert(false); // FIXME: getMemrefSource above already modified IR...
+      // return rewriter.notifyMatchFailure(dotOp, "not mappable to XSMM");
+    }
 
-    auto xsmmFuncs = xsmm::utils::buildBrgemmCalls(
-        rewriter, dotOp, ValueRange{lhsBuf, rhsBuf, accBuf}, *brgemmInfo,
-        flags);
+    auto xsmmFuncs = xsmm::utils::buildBrgemmCalls(rewriter, dotOp, inputs,
+                                                   indexingMaps, flags);
 
     if (hoistedAcc) {
       // Hoisting already updated all uses correctly.

--- a/third_party/cpu/lib/Xsmm/ConvertVectorToXsmm.cpp
+++ b/third_party/cpu/lib/Xsmm/ConvertVectorToXsmm.cpp
@@ -180,14 +180,14 @@ struct ContractToXsmm : public OpRewritePattern<vector::ContractionOp> {
     auto brgemmInfo =
         xsmm::utils::isMappableToBrgemm(rewriter, contractOp, inputs, outputs,
                                         contractOp.getIndexingMapsArray());
-    if (failed(brgemmInfo))
-      return rewriter.notifyMatchFailure(contractOp, "not mappable to XSMM");
-    if (brgemmInfo->isVnni)
-      return rewriter.notifyMatchFailure(contractOp, "VNNI support NYI");
+    if (failed(brgemmInfo)) {
+      assert(false); // FIXME: getMemrefSource above already modified IR...
+      // return rewriter.notifyMatchFailure(contractOp, "not mappable to XSMM");
+    }
 
     auto xsmmFuncs = xsmm::utils::buildBrgemmCalls(
-        rewriter, contractOp, ValueRange{lhsBuf, rhsBuf, accBuf}, *brgemmInfo,
-        flags);
+        rewriter, contractOp, ValueRange{lhsBuf, rhsBuf, accBuf},
+        contractOp.getIndexingMapsArray(), flags);
 
     if (hoistedAcc) {
       // Hoisting already updated all uses correctly.

--- a/third_party/cpu/lib/Xsmm/XsmmUtils.h
+++ b/third_party/cpu/lib/Xsmm/XsmmUtils.h
@@ -35,16 +35,16 @@ class Attribute;
 namespace xsmm {
 
 struct BrgemmInfo {
-  int64_t m;
-  int64_t n;
-  int64_t k;
-  int64_t batch;
+  OpFoldResult m;
+  OpFoldResult n;
+  OpFoldResult k;
+  OpFoldResult batch;
 
-  int64_t lda;
-  int64_t ldb;
-  int64_t ldc;
-  int64_t strideA;
-  int64_t strideB;
+  OpFoldResult lda;
+  OpFoldResult ldb;
+  OpFoldResult ldc;
+  OpFoldResult strideA;
+  OpFoldResult strideB;
 
   bool isVnni = false;
 };
@@ -110,18 +110,18 @@ getOperands(OpBuilder &builder, Location loc, ValueRange operands,
             IntegerAttr dataTypeAttr,
             std::optional<IntegerAttr> outDataTypeAttr = std::nullopt);
 
-FailureOr<BrgemmInfo> isMappableToBrgemm(PatternRewriter &rewriter,
-                                         Operation *contractOp,
-                                         SmallVector<Value> &inputs,
-                                         SmallVector<Value> &output,
-                                         ArrayRef<AffineMap> indexingMap);
+LogicalResult isMappableToBrgemm(PatternRewriter &rewriter,
+                                 Operation *contractOp,
+                                 SmallVector<Value> &inputs,
+                                 SmallVector<Value> &output,
+                                 ArrayRef<AffineMap> indexingMap);
 
 FailureOr<vector::ContractionOp>
 makeMinorDimensionsInnerMost(RewriterBase &rewriter,
                              vector::ContractionOp contractOp, unsigned m,
                              unsigned n, unsigned k, IntegerAttr type);
-std::optional<unsigned> getPosInCodomain(unsigned dim, Value operand,
-                                         Operation *contractOp, AffineMap map);
+std::optional<unsigned> getPosInCodomain(unsigned dim, AffineMap map,
+                                         MLIRContext *ctx);
 FailureOr<xsmm::BrgemmInfo>
 checkAccess(PatternRewriter &rewriter, Operation *contractOp, unsigned m,
             unsigned n, SmallVector<unsigned, 2> kVector,
@@ -152,7 +152,8 @@ buildInvokeCall(RewriterBase &rewriter, Location loc, ModuleOp module,
 // Create a pair of XSMM dispatch and invoke (BR)GEMM calls.
 std::pair<Operation *, Operation *>
 buildBrgemmCalls(PatternRewriter &rewriter, Operation *op, ValueRange inputs,
-                 xsmm::BrgemmInfo brgemmInfo, SmallVector<Attribute> flags);
+                 ArrayRef<AffineMap> indexingMaps,
+                 SmallVector<Attribute> flags);
 
 } // namespace utils
 } // namespace xsmm


### PR DESCRIPTION
Works on the IR generated by our modified V1 pipeline on `03-matrix-multiplication-cpu.py`.