### PR TITLE
Lower GEMM to BRGEMM kernel

### DIFF
--- a/third_party/cpu/include/Xsmm/Passes.td
+++ b/third_party/cpu/include/Xsmm/Passes.td
@@ -8,7 +8,8 @@ def ConvertVectorToXsmm : Pass<"triton-cpu-convert-vector-to-xsmm", "mlir::Modul
  let description = [{
    Convert vector operations to XSMM operations.
  }];
- let dependentDialects = ["func::FuncDialect",
+ let dependentDialects = ["arith::ArithDialect",
+                          "func::FuncDialect",
                           "memref::MemRefDialect",
                           "vector::VectorDialect",
 			                    "LLVM::LLVMDialect"];
@@ -19,9 +20,9 @@ def ConvertTritonToXsmm : Pass<"triton-cpu-convert-triton-to-xsmm", "mlir::Modul
  let description = [{
    Convert triton operations to XSMM operations.
  }];
- let dependentDialects = ["func::FuncDialect",
+ let dependentDialects = ["arith::ArithDialect",
+                          "func::FuncDialect",
                           "memref::MemRefDialect",
-                          "triton::TritonDialect",
                           "triton::cpu::TritonCPUDialect",
 			                    "LLVM::LLVMDialect"];
 }


### PR DESCRIPTION
Extends contraction lowering to XSMM by rewriting plain GEMM into a BRGEMM kernel when possible.

The rewrite improves performance of larger K block sizes thanks to extra reduction dim tiling. Use of BRGEMM kernel also enables online VNNI packing for BF16.
