### PR TITLE
Run the benchmark for each backend * config separately, without duplication 

### DIFF
--- a/run_all_benchmarks.sh
+++ b/run_all_benchmarks.sh
@@ -4,16 +4,36 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 source ../miniforge/bin/activate triton
 
-for datatype in f32 bf16; do
-  for num_threads in 1 $(nproc); do
-    for benchmark in xsmm-scalar xsmm-block; do
-      echo -e "\n\nRUN: $benchmark | threads $num_threads | type $datatype"
-      time $SCRIPT_DIR/python/tutorials/03-matrix-multiplication-cpu.sh $benchmark $num_threads --datatype $datatype $external_pad
+THREADS=$(lscpu | grep --color=never "Core.*socket" | grep -o "[0-9]\+")
+
+for datatype in f32 bf16 bf8; do
+  for num_threads in 1 $THREADS; do
+    for backend in torch-cpu-compile torch-cpu-native; do
+      config=baseline
+      echo -e "BENCHMARK: backend: $backend | config: $config | threads: $num_threads | type: $datatype"
+      time $SCRIPT_DIR/python/tutorials/03-matrix-multiplication-cpu.sh $config $num_threads --datatype $datatype --backend $backend 2>&1
+      echo -e "\n\n"
+    done
+
+    backend=triton-cpu
+    for config in baseline-scalar baseline-block; do
+      echo -e "BENCHMARK: backend: $backend | config: $config | threads: $num_threads | type: $datatype"
+      time $SCRIPT_DIR/python/tutorials/03-matrix-multiplication-cpu.sh $config $num_threads --datatype $datatype --backend $backend 2>&1
+      echo -e "\n\n"
+    done
+
+    # Triton-XSMM
+    backend=triton-xsmm
+    for config in xsmm-scalar xsmm-block; do
+      echo -e "BENCHMARK: backend: $backend | config: $config | threads: $num_threads | type: $datatype"
+      time $SCRIPT_DIR/python/tutorials/03-matrix-multiplication-cpu.sh $config $num_threads --datatype $datatype --backend $backend 2>&1
+      echo -e "\n\n"
     done
     for benchmark in xsmm-pad-k xsmm-loop-collapse-pad-b; do
       for external_pad in "" "--external-pad"; do
-        echo -e "\n\nRUN: $benchmark | threads $num_threads | type $datatype | $external_pad"
-        time $SCRIPT_DIR/python/tutorials/03-matrix-multiplication-cpu.sh $benchmark $num_threads --datatype $datatype $external_pad
+        echo -e "BENCHMARK: backend: $backend | config: $config | threads: $num_threads | type: $datatype | pad: $external_pad"
+        time $SCRIPT_DIR/python/tutorials/03-matrix-multiplication-cpu.sh $benchmark $num_threads --datatype $datatype --backend $backend $external_pad 2>&1
+        echo -e "\n\n"
       done
     done
   done


### PR DESCRIPTION
Add --backend option and run benchmark one backend*config option at a time

This branch allows for running baseline triton-cpu from the same script alongside all other backends & config options.
