### PR TITLE
Run bench

### DIFF
--- a/python/tutorials/03-matrix-multiplication-cpu.sh
+++ b/python/tutorials/03-matrix-multiplication-cpu.sh
@@ -77,10 +77,11 @@ export LD_LIBRARY_PATH=$XSMM_LIB_DIR:$LD_LIBRARY_PATH
 export LD_PRELOAD=/lib64/libomp.so:$LD_PRELOAD
 export TRITON_CPU_MAX_THREADS=${numthreads}
 export OMP_NUM_THREADS=${numthreads}
-# Hyper-Threading
-export KMP_AFFINITY=granularity=fine,compact,1,0
-# No Hyper-Threading
-#export KMP_AFFINITY=granularity=core,compact,0,0
+
+# Thread affinity changes with hyper-threading
+THREADS_PER_CORE=$(lscpu | grep --color=never "Thread.*core" | tee - | grep -o "[0-9]\+")
+SKIP=$((THREADS_PER_CORE-1)) # 0 for no HT, 1 for 2, 3 for 4, etc.
+export KMP_AFFINITY=granularity=fine,compact,$SKIP,0
 
 python $SCRIPT_DIR/03-matrix-multiplication-cpu.py
 

--- a/run_all_benchmarks.sh
+++ b/run_all_benchmarks.sh
@@ -45,13 +45,13 @@ RUN=time
 
 # Single-threaded just needs to run once for Torch baseline, because every multi-threaded run also runs single threaded
 echo -e "\nSingle-Threaded Baseline"
-$RUN $SCRIPT_DIR/python/tutorials/03-matrix-multiplication-cpu.sh xsmm-scalar $THREADS --DATATYPE $DATATYPE
+$RUN $SCRIPT_DIR/python/tutorials/03-matrix-multiplication-cpu.sh xsmm-scalar $THREADS --datatype $DATATYPE
 
 # Multi-threaded has two "flavours": baseline and XSMM
 echo -e "\nMulti-Threaded Baseline"
 for benchmark in xsmm-scalar xsmm-block; do
   echo -e "\nRUN: $benchmark | threads $THREADS | type $DATATYPE"
-  $RUN $SCRIPT_DIR/python/tutorials/03-matrix-multiplication-cpu.sh $benchmark $THREADS --DATATYPE $DATATYPE $external_pad
+  $RUN $SCRIPT_DIR/python/tutorials/03-matrix-multiplication-cpu.sh $benchmark $THREADS --datatype $DATATYPE $external_pad
 done
 
 # This should only run on a branch where the XSMM bridge is properly installed
@@ -60,7 +60,7 @@ if [ $BASELINE == 0 ]; then
   for benchmark in xsmm-pad-k xsmm-loop-collapse-pad-b; do
     for external_pad in "" "--external-pad"; do
       echo -e "\nRUN: $benchmark | threads $THREADS | type $DATATYPE | $external_pad"
-      $RUN $SCRIPT_DIR/python/tutorials/03-matrix-multiplication-cpu.sh $benchmark $THREADS --DATATYPE $DATATYPE $external_pad
+      $RUN $SCRIPT_DIR/python/tutorials/03-matrix-multiplication-cpu.sh $benchmark $THREADS --datatype $DATATYPE $external_pad
     done
   done
 fi

--- a/run_all_benchmarks.sh
+++ b/run_all_benchmarks.sh
@@ -45,7 +45,7 @@ RUN=time
 
 # Single-threaded just needs to run once for Torch baseline, because every multi-threaded run also runs single threaded
 echo -e "\nSingle-Threaded Baseline"
-$RUN $SCRIPT_DIR/python/tutorials/03-matrix-multiplication-cpu.sh xsmm-scalar $THREADS --datatype $DATATYPE
+$RUN $SCRIPT_DIR/python/tutorials/03-matrix-multiplication-cpu.sh xsmm-scalar 1 --datatype $DATATYPE
 
 # Multi-threaded has two "flavours": baseline and XSMM
 echo -e "\nMulti-Threaded Baseline"

--- a/run_all_benchmarks.sh
+++ b/run_all_benchmarks.sh
@@ -45,7 +45,10 @@ RUN=time
 
 # Single-threaded just needs to run once for Torch baseline, because every multi-threaded run also runs single threaded
 echo -e "\nSingle-Threaded Baseline"
+echo -e "\nRUN: single-scalar | threads 1 | type $DATATYPE"
 $RUN $SCRIPT_DIR/python/tutorials/03-matrix-multiplication-cpu.sh xsmm-scalar 1 --datatype $DATATYPE
+echo -e "\nRUN: single-block | threads 1 | type $DATATYPE"
+$RUN $SCRIPT_DIR/python/tutorials/03-matrix-multiplication-cpu.sh xsmm-block 1 --datatype $DATATYPE
 
 # Multi-threaded has two "flavours": baseline and XSMM
 echo -e "\nMulti-Threaded Baseline"

--- a/run_all_benchmarks.sh
+++ b/run_all_benchmarks.sh
@@ -2,21 +2,67 @@
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
+# Default data type
+DATATYPE=f32
+# Default to thread 0 on every core of the first socket
+# _see KMP_AFFINITY in 03-matrix-multiplication-cpu.sh_
+THREADS=$(lscpu | grep --color=never "Core.*socket" | grep -o "[0-9]\+")
+# Default to run XSMM benchmarks
+BASELINE=0
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    bf16)
+      DATATYPE=$1
+      shift
+      ;;
+    bf8)
+      DATATYPE=$1
+      shift
+      ;;
+    --baseline)
+      BASELINE=1
+      shift
+      ;;
+    *)
+      if ! [[ "$1" =~ ^[0-9]+$ ]]; then
+        echo "ERROR: Syntax: run_all_benchmarks <f32|bf16|bf8> <THREADS> [--baseline]"
+        exit 1
+      fi
+      THREADS=$1
+      shift
+      ;;
+  esac
+done
+echo "DATATYPE = $DATATYPE"
+echo "Num Threads = $THREADS"
+
 source ../miniforge/bin/activate triton
 
-for datatype in f32 bf16; do
-  for num_threads in 1 $(nproc); do
-    for benchmark in xsmm-scalar xsmm-block; do
-      echo -e "\n\nRUN: $benchmark | threads $num_threads | type $datatype"
-      time $SCRIPT_DIR/python/tutorials/03-matrix-multiplication-cpu.sh $benchmark $num_threads --datatype $datatype $external_pad
-    done
-    for benchmark in xsmm-pad-k xsmm-loop-collapse-pad-b; do
-      for external_pad in "" "--external-pad"; do
-        echo -e "\n\nRUN: $benchmark | threads $num_threads | type $datatype | $external_pad"
-        time $SCRIPT_DIR/python/tutorials/03-matrix-multiplication-cpu.sh $benchmark $num_threads --datatype $datatype $external_pad
-      done
+# Debug only
+#RUN=echo
+RUN=time
+
+# Single-threaded just needs to run once for Torch baseline, because every multi-threaded run also runs single threaded
+echo -e "\nSingle-Threaded Baseline"
+$RUN $SCRIPT_DIR/python/tutorials/03-matrix-multiplication-cpu.sh xsmm-scalar $THREADS --DATATYPE $DATATYPE
+
+# Multi-threaded has two "flavours": baseline and XSMM
+echo -e "\nMulti-Threaded Baseline"
+for benchmark in xsmm-scalar xsmm-block; do
+  echo -e "\nRUN: $benchmark | threads $THREADS | type $DATATYPE"
+  $RUN $SCRIPT_DIR/python/tutorials/03-matrix-multiplication-cpu.sh $benchmark $THREADS --DATATYPE $DATATYPE $external_pad
+done
+
+# This should only run on a branch where the XSMM bridge is properly installed
+if [ $BASELINE == 0 ]; then
+  echo -e "\nMulti-Threaded XSMM"
+  for benchmark in xsmm-pad-k xsmm-loop-collapse-pad-b; do
+    for external_pad in "" "--external-pad"; do
+      echo -e "\nRUN: $benchmark | threads $THREADS | type $DATATYPE | $external_pad"
+      $RUN $SCRIPT_DIR/python/tutorials/03-matrix-multiplication-cpu.sh $benchmark $THREADS --DATATYPE $DATATYPE $external_pad
     done
   done
-done
+fi
 
 conda deactivate


### PR DESCRIPTION
This changes the run to avoid running unnecessary benchmarks.

The single-threaded runs every time, so having a whole loop for it is unnecessary.
The baseline (non-XSMM) only needs to be run once, since the XSMM options make no difference. We set to scalar/block pointer semantics to gather all data.

Options:
 * datatype: f32, bf16, bf8 (default f32)
 * threads: default cores per socket (no HT)
 * baseline: run xsmm benchmarks or not

