### PR TITLE
comment/disable xsmm usage in pytorch padding extension

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -23,8 +23,8 @@ if [ $? != 0 ]; then
 fi
 
 echo "===================================== Setting up LIBXSMM for paddeing"
-export XSMM_ROOT_DIR=$(realpath $(find python/build/ -type d -name xsmm-src | grep -v third_party))
-export XSMM_LIB_DIR=$(realpath python/triton/_C)
+#export XSMM_ROOT_DIR=$(realpath $(find python/build/ -type d -name xsmm-src | grep -v third_party))
+#export XSMM_LIB_DIR=$(realpath python/triton/_C)
 cd third_party/cpu/python
 python setup.py install
 cd ../../../

--- a/python/tutorials/03-matrix-multiplication-cpu.sh
+++ b/python/tutorials/03-matrix-multiplication-cpu.sh
@@ -111,8 +111,8 @@ else
 fi
 
 # Uses the libxsmm built in the repo
-export XSMM_LIB_DIR=$SCRIPT_DIR/../triton/_C/
-export LD_LIBRARY_PATH=$XSMM_LIB_DIR:$LD_LIBRARY_PATH
+#export XSMM_LIB_DIR=$SCRIPT_DIR/../triton/_C/
+#export LD_LIBRARY_PATH=$XSMM_LIB_DIR:$LD_LIBRARY_PATH
 export LD_PRELOAD=/lib64/libomp.so:$LD_PRELOAD
 if [ -e "$numthreads" ]; then
   echo "ERROR: must specify numthreads as 2nd arg"; exit 1

--- a/third_party/cpu/python/setup.py
+++ b/third_party/cpu/python/setup.py
@@ -2,20 +2,25 @@ from setuptools import setup, Extension
 from torch.utils import cpp_extension
 import os
 
-xsmm_root = os.getenv("XSMM_ROOT_DIR")
-xsmm_lib = os.getenv("XSMM_LIB_DIR")
-print(f'Using LIBXSMM root: {xsmm_root}')
-print(f'LIBXSMM lib location: {xsmm_lib}')
+#xsmm_root = os.getenv("XSMM_ROOT_DIR")
+#xsmm_lib = os.getenv("XSMM_LIB_DIR")
+#print(f'Using LIBXSMM root: {xsmm_root}')
+#print(f'LIBXSMM lib location: {xsmm_lib}')
 
 setup(name='xsmm_py',
+#      ext_modules=[
+#          cpp_extension.CppExtension('xsmm_py', ['xsmm_utils.cpp'],
+#          include_dirs=[
+#              f'{xsmm_root}/include',
+#              f'{xsmm_root}/src/template'
+#          ],
+#          library_dirs=[f'{xsmm_lib}'],
+#          libraries=['xsmm', 'omp'],
+#          extra_compile_args=['-fopenmp']
+#      )],
       ext_modules=[
           cpp_extension.CppExtension('xsmm_py', ['xsmm_utils.cpp'],
-          include_dirs=[
-              f'{xsmm_root}/include',
-              f'{xsmm_root}/src/template'
-          ],
-          library_dirs=[f'{xsmm_lib}'],
-          libraries=['xsmm', 'omp'],
+          libraries=['omp'],
           extra_compile_args=['-fopenmp']
       )],
       cmdclass={'build_ext': cpp_extension.BuildExtension})

--- a/third_party/cpu/python/xsmm_utils.cpp
+++ b/third_party/cpu/python/xsmm_utils.cpp
@@ -1,6 +1,8 @@
 #include <torch/extension.h>
 
+#if 0
 #include "libxsmm.h"
+#endif
 #include <omp.h>
 
 #include <cstring>
@@ -14,6 +16,7 @@ void fastZeroPad2D(const at::Tensor &input, torch::Tensor &output) {
              outSizes[1] >= inSizes[1] && byteSize == output.element_size() &&
              "Invalid fastZeroPad2D tensors");
 
+#if 0
   libxsmm_datatype dtype;
   if (byteSize == 4)
     dtype = LIBXSMM_DATATYPE_F32;
@@ -36,6 +39,7 @@ void fastZeroPad2D(const at::Tensor &input, torch::Tensor &output) {
   libxsmm_bitfield flags = LIBXSMM_MELTW_FLAG_UNARY_NONE;
   libxsmm_meltwfunction_unary identityFn = libxsmm_dispatch_meltw_unary(
       LIBXSMM_MELTW_TYPE_UNARY_IDENTITY, shape, flags);
+#endif
 
   void *baseIn = input.data_ptr();
   void *outIn = output.data_ptr();


### PR DESCRIPTION
we are not using xsmm for padding extension atm. This patch also disables/comments stuff which was still there in case of xsmm is used for padding extension.